### PR TITLE
feat: new lazy system API

### DIFF
--- a/ecsact/runtime/dynamic.h
+++ b/ecsact/runtime/dynamic.h
@@ -228,6 +228,19 @@ ECSACT_DYNAMIC_API_FN(ecsact_system_id, ecsact_create_system)
 	int32_t           system_name_len
 );
 
+/**
+ * Set a systems 'lazy' execution iteration rate. This affects how many entities
+ * a system is executed on per `ecsact_execute_systems` call.
+ *
+ * By default the iteration rate is `0` which means a system is _not_ lazy and
+ * will run on every entity the system qualifies for.
+ */
+ECSACT_DYNAMIC_API_FN(void, ecsact_set_system_lazy_iteration_rate)
+( //
+	ecsact_system_id system_id,
+	int32_t          iteration_rate
+);
+
 ECSACT_DYNAMIC_API_FN(void, ecsact_add_child_system)
 ( //
 	ecsact_system_like_id parent,
@@ -431,6 +444,7 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_system_generates_unset_component)
 		fn(ecsact_remove_dependency, __VA_ARGS__);                   \
 		fn(ecsact_destroy_package, __VA_ARGS__);                     \
 		fn(ecsact_create_system, __VA_ARGS__);                       \
+		fn(ecsact_set_system_lazy_iteration_rate, __VA_ARGS__);      \
 		fn(ecsact_add_child_system, __VA_ARGS__);                    \
 		fn(ecsact_remove_child_system, __VA_ARGS__);                 \
 		fn(ecsact_reorder_system, __VA_ARGS__);                      \

--- a/ecsact/runtime/meta.h
+++ b/ecsact/runtime/meta.h
@@ -400,6 +400,14 @@ ECSACT_META_API_FN(void, ecsact_meta_get_top_level_systems)
 	int32_t*               out_systems_count
 );
 
+/**
+ * Get the lazy iteration rate of a system. Returns `0` if system is not lazy.
+ */
+ECSACT_META_API_FN(int32_t, ecsact_meta_get_lazy_iteration_rate)
+( //
+	ecsact_system_id system_id
+);
+
 // # BEGIN FOR_EACH_ECSACT_META_API_FN
 #ifdef ECSACT_MSVC_TRADITIONAL
 #	define FOR_EACH_ECSACT_META_API_FN(fn, ...) ECSACT_MSVC_TRADITIONAL_ERROR()
@@ -453,7 +461,8 @@ ECSACT_META_API_FN(void, ecsact_meta_get_top_level_systems)
 		fn(ecsact_meta_get_child_system_ids, __VA_ARGS__);                  \
 		fn(ecsact_meta_get_parent_system_id, __VA_ARGS__);                  \
 		fn(ecsact_meta_count_top_level_systems, __VA_ARGS__);               \
-		fn(ecsact_meta_get_top_level_systems, __VA_ARGS__)
+		fn(ecsact_meta_get_top_level_systems, __VA_ARGS__);                 \
+		fn(ecsact_meta_get_lazy_iteration_rate, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_META_H


### PR DESCRIPTION
Systems now can be marked as 'lazy' meaning they only run on a small
subset of the entities they qualify for per ecsact_system_execution
call. We're adding this to increase performance for systems that don't
strictly need to run on every entity every execution loop.
