### PR TITLE
fix: force inline for c++ wrappers

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "b046ce3a8e15ef10c4171d9d1895dbce6a57866744a05f38bd06640a1cfc8ca3",
+  "moduleFileHash": "fbe2bd4bda5579ba17aff8050a0f460224d22cd292da917f9d377ae1cff13209",
   "flags": {
     "cmdRegistries": [
       "https://raw.githubusercontent.com/ecsact-dev/bazel_registry/main",
@@ -63,7 +63,7 @@
       ],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "googletest": "googletest@1.14.0",
         "abseil-cpp": "abseil-cpp@20230802.0",
@@ -104,7 +104,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -124,14 +124,32 @@
         }
       }
     },
-    "platforms@0.0.8": {
+    "platforms@0.0.9": {
       "name": "platforms",
-      "version": "0.0.8",
-      "key": "platforms@0.0.8",
+      "version": "0.0.9",
+      "key": "platforms@0.0.9",
       "repoName": "platforms",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
-      "extensionUsages": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@platforms//host:extension.bzl",
+          "extensionName": "host_platform",
+          "usingModule": "platforms@0.0.9",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel",
+            "line": 9,
+            "column": 30
+          },
+          "imports": {
+            "host_platform": "host_platform"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
       "deps": {
         "rules_license": "rules_license@0.0.7",
         "bazel_tools": "bazel_tools@_",
@@ -142,9 +160,9 @@
         "ruleClassName": "http_archive",
         "attributes": {
           "urls": [
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz"
           ],
-          "integrity": "sha256-gVBAZgU4ns7LbaB8vLUJ1WN6OrmiS8abEQFTE2fYnXQ=",
+          "integrity": "sha256-XtpTnIQSZQMcL4LYrno6ZJC9YhduDAOPxGnqv5H2FJs=",
           "strip_prefix": "",
           "remote_patches": {},
           "remote_patch_strip": 0
@@ -163,7 +181,7 @@
       ],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -191,7 +209,7 @@
       "extensionUsages": [],
       "deps": {
         "com_google_absl": "abseil-cpp@20230802.0",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -222,7 +240,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "com_google_googletest": "googletest@1.14.0",
         "com_github_google_benchmark": "google_benchmark@1.8.2",
@@ -298,7 +316,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "boost.algorithm": "boost.algorithm@1.83.0.bzl.1",
         "boost.asio": "boost.asio@1.83.0.bzl.2",
@@ -345,7 +363,7 @@
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -582,7 +600,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "rules_python": "rules_python@0.22.1",
         "buildozer": "buildozer@6.4.0.2",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "com_google_protobuf": "protobuf@21.7",
         "zlib": "zlib@1.3",
         "build_bazel_apple_support": "apple_support@1.5.0",
@@ -598,7 +616,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_"
       }
     },
@@ -638,7 +656,7 @@
       "extensionUsages": [],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "rules_foreign_cc": "rules_foreign_cc@0.9.0",
         "rules_cc": "rules_cc@0.0.9",
         "libpfm": "libpfm@4.11.0",
@@ -1203,7 +1221,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "boringssl": "boringssl@0.0.0-20230215-5c22014",
         "boost.align": "boost.align@1.83.0.bzl.1",
@@ -1530,7 +1548,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "rules_proto": "rules_proto@5.3.0-21.7",
@@ -1666,7 +1684,7 @@
         }
       ],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_skylib": "bazel_skylib@1.5.0",
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
@@ -1848,7 +1866,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "rules_cc": "rules_cc@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -1901,7 +1919,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1967,7 +1985,7 @@
       ],
       "deps": {
         "bazel_skylib": "bazel_skylib@1.5.0",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -1997,7 +2015,7 @@
       "toolchainsToRegister": [],
       "extensionUsages": [],
       "deps": {
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "rules_foreign_cc": "rules_foreign_cc@0.9.0",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
@@ -2833,7 +2851,7 @@
       "extensionUsages": [],
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },
@@ -3153,7 +3171,7 @@
         "rules_proto": "rules_proto@5.3.0-21.7",
         "com_google_protobuf": "protobuf@21.7",
         "com_google_absl": "abseil-cpp@20230802.0",
-        "platforms": "platforms@0.0.8",
+        "platforms": "platforms@0.0.9",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       },

--- a/ecsact/runtime/async.hh
+++ b/ecsact/runtime/async.hh
@@ -139,27 +139,27 @@ private:
 	}
 };
 
-[[nodiscard]] inline auto connect( //
+[[nodiscard]] ECSACT_ALWAYS_INLINE auto connect(
 	const std::string& connection_string
 ) -> ecsact_async_request_id {
 	return ecsact_async_connect(connection_string.c_str());
 }
 
-inline auto disconnect() -> void {
+ECSACT_ALWAYS_INLINE auto disconnect() -> void {
 	ecsact_async_disconnect();
 }
 
-[[nodiscard]] inline auto get_current_tick() -> int32_t {
+[[nodiscard]] ECSACT_ALWAYS_INLINE auto get_current_tick() -> int32_t {
 	return ecsact_async_get_current_tick();
 }
 
-[[nodiscard]] inline auto enqueue_execution_options(
+[[nodiscard]] ECSACT_ALWAYS_INLINE auto enqueue_execution_options(
 	ecsact::core::execution_options& options
 ) -> ecsact_async_request_id {
 	return ecsact_async_enqueue_execution_options(options.c());
 }
 
-inline auto flush_events() -> void {
+ECSACT_ALWAYS_INLINE auto flush_events() -> void {
 	ecsact_async_flush_events(nullptr, nullptr);
 }
 
@@ -167,7 +167,9 @@ template<typename ExecutionEventsCollector>
 	requires(std::convertible_to<
 						decltype(std::declval<ExecutionEventsCollector>().c()),
 						const ecsact_execution_events_collector>)
-inline auto flush_events(ExecutionEventsCollector&& evc) -> void {
+ECSACT_ALWAYS_INLINE auto flush_events( //
+	ExecutionEventsCollector&& evc
+) -> void {
 	const ecsact_execution_events_collector evc_c = evc.c();
 	ecsact_async_flush_events(&evc_c, nullptr);
 }
@@ -176,13 +178,15 @@ template<typename AsyncEventsCollector>
 	requires(std::convertible_to<
 						decltype(std::declval<AsyncEventsCollector>().c()),
 						const ecsact_async_events_collector>)
-inline auto flush_events(AsyncEventsCollector&& async_evc) -> void {
+ECSACT_ALWAYS_INLINE auto flush_events( //
+	AsyncEventsCollector&& async_evc
+) -> void {
 	const ecsact_async_events_collector async_evc_c = async_evc.c();
 	ecsact_async_flush_events(nullptr, &async_evc_c);
 }
 
 template<typename ExecutionEventsCollector, typename AsyncEventsCollector>
-inline auto flush_events(
+ECSACT_ALWAYS_INLINE auto flush_events(
 	ExecutionEventsCollector&& evc,
 	AsyncEventsCollector&&     async_evc
 ) -> void {

--- a/ecsact/runtime/common.h
+++ b/ecsact/runtime/common.h
@@ -27,6 +27,12 @@
 #	define ECSACT_IMPORT(ImportModule, ImportName)
 #endif
 
+#ifdef _MSC_VER
+#	define ECSACT_ALWAYS_INLINE __forceinline
+#else
+#	define ECSACT_ALWAYS_INLINE __attribute__((always_inline))
+#endif
+
 ECSACT_TYPED_ID(ecsact_package_id);
 ECSACT_TYPED_ID(ecsact_system_id);
 ECSACT_TYPED_ID(ecsact_action_id);
@@ -50,13 +56,13 @@ ECSACT_TYPED_ID(ecsact_component_like_id);
 #ifdef __cplusplus
 template<typename To, typename From>
 To ecsact_id_cast(From);
-#	define ECSACT_CAST_ID_FN(From, To)             \
-		template<>                                    \
-		inline To ecsact_id_cast<To, From>(From id) { \
-			return (To)id;                              \
+#	define ECSACT_CAST_ID_FN(From, To)                           \
+		template<>                                                  \
+		ECSACT_ALWAYS_INLINE To ecsact_id_cast<To, From>(From id) { \
+			return (To)id;                                            \
 		}
 #else
-inline int32_t ecsact_id_cast(int32_t id) {
+ECSACT_ALWAYS_INLINE int32_t ecsact_id_cast(int32_t id) {
 	return id;
 }
 
@@ -361,9 +367,8 @@ typedef int (*ecsact_action_compare_fn_t)(const void* a, const void* b);
  * necessary function. Any 32 bit integer >=0 is a valid placeholder entity ID.
  * Integers <0 are reserved as special placeholder IDs.
  */
-inline ecsact_placeholder_entity_id ecsact_util_make_placeholder_entity_id(
-	int32_t id
-) {
+ECSACT_ALWAYS_INLINE ecsact_placeholder_entity_id
+ecsact_util_make_placeholder_entity_id(int32_t id) {
 	return (ecsact_placeholder_entity_id)id;
 }
 

--- a/ecsact/runtime/core.hh
+++ b/ecsact/runtime/core.hh
@@ -441,8 +441,9 @@ public:
 
 	template<typename Component>
 		requires(!std::is_empty_v<Component>)
-	ECSACT_ALWAYS_INLINE const Component& get_component(ecsact_entity_id entity_id
-	) {
+	ECSACT_ALWAYS_INLINE auto get_component( //
+		ecsact_entity_id entity_id
+	) -> const Component& {
 		return *reinterpret_cast<const Component*>(
 			ecsact_get_component(_id, entity_id, Component::id)
 		);
@@ -492,7 +493,8 @@ public:
 		return entities;
 	}
 
-	ECSACT_ALWAYS_INLINE auto count_components(ecsact_entity_id entity
+	ECSACT_ALWAYS_INLINE auto count_components( //
+		ecsact_entity_id entity
 	) const -> int32_t {
 		return ecsact_count_components(_id, entity);
 	}

--- a/ecsact/runtime/core.hh
+++ b/ecsact/runtime/core.hh
@@ -14,7 +14,7 @@ class builder_entity {
 
 public:
 	template<typename C>
-	inline builder_entity& add_component(C* component) {
+	ECSACT_ALWAYS_INLINE auto add_component(C* component) -> builder_entity& {
 		components.push_back(ecsact_component{
 			.component_id = C::id,
 			.component_data = component,
@@ -58,12 +58,12 @@ public:
 	}
 
 	template<typename C>
-	inline void remove_component(ecsact_entity_id entity_id) {
+	ECSACT_ALWAYS_INLINE void remove_component(ecsact_entity_id entity_id) {
 		remove_component_ids_container.push_back(C::id);
 		remove_entities_container.push_back(entity_id);
 	}
 
-	inline void remove_component(
+	ECSACT_ALWAYS_INLINE void remove_component(
 		ecsact_entity_id    entity_id,
 		ecsact_component_id component_id
 	) {
@@ -71,15 +71,15 @@ public:
 		remove_entities_container.push_back(entity_id);
 	}
 
-	inline builder_entity& create_entity(
+	ECSACT_ALWAYS_INLINE auto create_entity(
 		ecsact_placeholder_entity_id placeholder_entity_id = {}
-	) {
+	) -> builder_entity& {
 		auto& builder = create_entities.emplace_back();
 		builder.placeholder_entity_id = placeholder_entity_id;
 		return builder;
 	}
 
-	inline void destroy_entity(const ecsact_entity_id& entity_id) {
+	ECSACT_ALWAYS_INLINE void destroy_entity(const ecsact_entity_id& entity_id) {
 		destroy_entities.push_back(entity_id);
 	}
 
@@ -88,11 +88,11 @@ public:
 	 * `ecsact::core::execution_options` destructor occurs or `clear()` occurs.
 	 */
 	template<typename Action>
-	inline void push_action(const Action* action) {
+	ECSACT_ALWAYS_INLINE void push_action(const Action* action) {
 		actions.push_back(ecsact_action{Action::id, action});
 	}
 
-	inline void clear() {
+	ECSACT_ALWAYS_INLINE void clear() {
 		add_entities_container.clear();
 		add_components_container.clear();
 
@@ -111,7 +111,7 @@ public:
 		actions.clear();
 	}
 
-	inline ecsact_execution_options c() {
+	ECSACT_ALWAYS_INLINE auto c() -> ecsact_execution_options {
 		auto options = ecsact_execution_options{};
 
 		options.add_components_length = add_components_container.size();
@@ -441,25 +441,26 @@ public:
 
 	template<typename Component>
 		requires(!std::is_empty_v<Component>)
-	inline const Component& get_component(ecsact_entity_id entity_id) {
+	ECSACT_ALWAYS_INLINE const Component& get_component(ecsact_entity_id entity_id
+	) {
 		return *reinterpret_cast<const Component*>(
 			ecsact_get_component(_id, entity_id, Component::id)
 		);
 	}
 
 	template<typename Component>
-	inline bool has_component(ecsact_entity_id entity_id) {
+	ECSACT_ALWAYS_INLINE bool has_component(ecsact_entity_id entity_id) {
 		return ecsact_has_component(_id, entity_id, Component::id);
 	}
 
 	template<typename Component>
 		requires(std::is_empty_v<Component>)
-	inline auto add_component(ecsact_entity_id entity_id) {
+	ECSACT_ALWAYS_INLINE auto add_component(ecsact_entity_id entity_id) {
 		return ecsact_add_component(_id, entity_id, Component::id, nullptr);
 	}
 
 	template<typename Component>
-	inline auto add_component(
+	ECSACT_ALWAYS_INLINE auto add_component(
 		ecsact_entity_id entity_id,
 		const Component& component
 	) {
@@ -471,18 +472,19 @@ public:
 	}
 
 	template<typename Component>
-	inline auto update_component(
+	ECSACT_ALWAYS_INLINE auto update_component(
 		ecsact_entity_id entity_id,
 		const Component& component
 	) {
 		return ecsact_update_component(_id, entity_id, Component::id, &component);
 	}
 
-	inline auto count_entities() const -> int32_t {
+	ECSACT_ALWAYS_INLINE auto count_entities() const -> int32_t {
 		return ecsact_count_entities(_id);
 	}
 
-	inline auto get_entities() const -> std::vector<ecsact_entity_id> {
+	ECSACT_ALWAYS_INLINE auto get_entities() const
+		-> std::vector<ecsact_entity_id> {
 		const auto entities_count = count_entities();
 		auto       entities = std::vector<ecsact_entity_id>{};
 		entities.resize(entities_count);
@@ -490,7 +492,8 @@ public:
 		return entities;
 	}
 
-	inline auto count_components(ecsact_entity_id entity) const -> int32_t {
+	ECSACT_ALWAYS_INLINE auto count_components(ecsact_entity_id entity
+	) const -> int32_t {
 		return ecsact_count_components(_id, entity);
 	}
 
@@ -507,7 +510,8 @@ public:
 	 * in @p execution_options range.
 	 */
 	template<typename ExecutionOptionsRange>
-	[[nodiscard]] auto execute_systems(ExecutionOptionsRange&& execution_options
+	[[nodiscard]] auto execute_systems( //
+		ExecutionOptionsRange&& execution_options
 	) -> ecsact_execute_systems_error {
 		auto        execution_count = std::size(execution_options);
 		const auto* execution_options_list_data = std::data(execution_options);
@@ -545,16 +549,16 @@ public:
 	}
 
 	template<typename ExecutionEventsCollector>
-	auto execute_systems(
+	ECSACT_ALWAYS_INLINE auto execute_systems( //
 		int32_t                    execution_count,
 		ExecutionEventsCollector&& evc
-	) {
+	) -> void {
 		const ecsact_execution_events_collector evc_c = evc.c();
 		execute_systems(execution_count, evc_c);
 	}
 
 	template<typename ExecutionOptionsRange, typename ExecutionEventsCollector>
-	[[nodiscard]] auto execute_systems(
+	[[nodiscard]] ECSACT_ALWAYS_INLINE auto execute_systems(
 		ExecutionOptionsRange&&    execution_options,
 		ExecutionEventsCollector&& evc
 	) -> ecsact_execute_systems_error {

--- a/ecsact/runtime/meta.hh
+++ b/ecsact/runtime/meta.hh
@@ -9,7 +9,7 @@
 
 namespace ecsact::meta {
 
-inline std::vector<ecsact_package_id> get_package_ids() {
+ECSACT_ALWAYS_INLINE std::vector<ecsact_package_id> get_package_ids() {
 	std::vector<ecsact_package_id> package_ids;
 	package_ids.resize(ecsact_meta_count_packages());
 	ecsact_meta_get_package_ids(
@@ -20,7 +20,9 @@ inline std::vector<ecsact_package_id> get_package_ids() {
 	return package_ids;
 }
 
-inline std::vector<ecsact_package_id> get_package_ids(int32_t max_size) {
+ECSACT_ALWAYS_INLINE std::vector<ecsact_package_id> get_package_ids(
+	int32_t max_size
+) {
 	std::vector<ecsact_package_id> package_ids;
 	package_ids.resize(max_size);
 	ecsact_meta_get_package_ids(max_size, package_ids.data(), &max_size);
@@ -28,7 +30,9 @@ inline std::vector<ecsact_package_id> get_package_ids(int32_t max_size) {
 	return package_ids;
 }
 
-inline std::filesystem::path package_file_path(ecsact_package_id package_id) {
+ECSACT_ALWAYS_INLINE std::filesystem::path package_file_path(
+	ecsact_package_id package_id
+) {
 	auto file_path = ecsact_meta_package_file_path(package_id);
 	if(file_path == nullptr) {
 		return {};
@@ -36,7 +40,7 @@ inline std::filesystem::path package_file_path(ecsact_package_id package_id) {
 	return std::filesystem::path(file_path);
 }
 
-inline std::string package_name(ecsact_package_id package_id) {
+ECSACT_ALWAYS_INLINE std::string package_name(ecsact_package_id package_id) {
 	auto pkg_name = ecsact_meta_package_name(package_id);
 	if(pkg_name == nullptr) {
 		return {};
@@ -44,7 +48,7 @@ inline std::string package_name(ecsact_package_id package_id) {
 	return pkg_name;
 }
 
-inline std::vector<ecsact_package_id> get_dependencies(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_package_id> get_dependencies(
 	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_package_id> dep_ids;
@@ -58,7 +62,7 @@ inline std::vector<ecsact_package_id> get_dependencies(
 	return dep_ids;
 }
 
-inline std::vector<ecsact_package_id> get_dependencies(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_package_id> get_dependencies(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -69,7 +73,7 @@ inline std::vector<ecsact_package_id> get_dependencies(
 	return dep_ids;
 }
 
-inline std::vector<ecsact_component_id> get_component_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_component_id> get_component_ids(
 	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_component_id> component_ids;
@@ -83,7 +87,7 @@ inline std::vector<ecsact_component_id> get_component_ids(
 	return component_ids;
 }
 
-inline std::vector<ecsact_component_id> get_component_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_component_id> get_component_ids(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -99,7 +103,8 @@ inline std::vector<ecsact_component_id> get_component_ids(
 	return component_ids;
 }
 
-inline std::string component_name(ecsact_component_id component_id) {
+ECSACT_ALWAYS_INLINE std::string component_name(ecsact_component_id component_id
+) {
 	auto comp_name = ecsact_meta_component_name(component_id);
 	if(comp_name == nullptr) {
 		return {};
@@ -107,7 +112,7 @@ inline std::string component_name(ecsact_component_id component_id) {
 	return comp_name;
 }
 
-inline std::vector<ecsact_transient_id> get_transient_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_transient_id> get_transient_ids(
 	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_transient_id> transient_ids;
@@ -121,7 +126,7 @@ inline std::vector<ecsact_transient_id> get_transient_ids(
 	return transient_ids;
 }
 
-inline std::vector<ecsact_transient_id> get_transient_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_transient_id> get_transient_ids(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -137,7 +142,8 @@ inline std::vector<ecsact_transient_id> get_transient_ids(
 	return transient_ids;
 }
 
-inline std::string transient_name(ecsact_transient_id transient_id) {
+ECSACT_ALWAYS_INLINE std::string transient_name(ecsact_transient_id transient_id
+) {
 	auto comp_name = ecsact_meta_transient_name(transient_id);
 	if(comp_name == nullptr) {
 		return {};
@@ -146,7 +152,8 @@ inline std::string transient_name(ecsact_transient_id transient_id) {
 }
 
 template<typename CompositeID>
-inline std::vector<ecsact_field_id> get_field_ids(CompositeID id) {
+ECSACT_ALWAYS_INLINE std::vector<ecsact_field_id> get_field_ids(CompositeID id
+) {
 	std::vector<ecsact_field_id> field_ids;
 	auto compo_id = ecsact_id_cast<ecsact_composite_id>(id);
 	field_ids.resize(ecsact_meta_count_fields(compo_id));
@@ -160,7 +167,7 @@ inline std::vector<ecsact_field_id> get_field_ids(CompositeID id) {
 }
 
 template<typename CompositeID>
-inline std::vector<ecsact_field_id> get_field_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_field_id> get_field_ids(
 	CompositeID id,
 	int32_t     max_size
 ) {
@@ -172,7 +179,8 @@ inline std::vector<ecsact_field_id> get_field_ids(
 	return field_ids;
 }
 
-inline std::vector<ecsact_system_id> get_system_ids(ecsact_package_id package_id
+ECSACT_ALWAYS_INLINE std::vector<ecsact_system_id> get_system_ids(
+	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_system_id> system_ids;
 	system_ids.resize(ecsact_meta_count_systems(package_id));
@@ -185,7 +193,7 @@ inline std::vector<ecsact_system_id> get_system_ids(ecsact_package_id package_id
 	return system_ids;
 }
 
-inline std::vector<ecsact_system_id> get_system_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_system_id> get_system_ids(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -201,7 +209,7 @@ inline std::vector<ecsact_system_id> get_system_ids(
 	return system_ids;
 }
 
-inline std::string system_name(ecsact_system_id system_id) {
+ECSACT_ALWAYS_INLINE std::string system_name(ecsact_system_id system_id) {
 	auto name = ecsact_meta_system_name(system_id);
 	if(name == nullptr) {
 		return {};
@@ -209,7 +217,8 @@ inline std::string system_name(ecsact_system_id system_id) {
 	return name;
 }
 
-inline std::vector<ecsact_action_id> get_action_ids(ecsact_package_id package_id
+ECSACT_ALWAYS_INLINE std::vector<ecsact_action_id> get_action_ids(
+	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_action_id> action_ids;
 	action_ids.resize(ecsact_meta_count_actions(package_id));
@@ -222,7 +231,7 @@ inline std::vector<ecsact_action_id> get_action_ids(ecsact_package_id package_id
 	return action_ids;
 }
 
-inline std::vector<ecsact_action_id> get_action_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_action_id> get_action_ids(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -238,7 +247,7 @@ inline std::vector<ecsact_action_id> get_action_ids(
 	return action_ids;
 }
 
-inline std::string action_name(ecsact_action_id action_id) {
+ECSACT_ALWAYS_INLINE std::string action_name(ecsact_action_id action_id) {
 	auto name = ecsact_meta_action_name(action_id);
 	if(name == nullptr) {
 		return {};
@@ -246,7 +255,9 @@ inline std::string action_name(ecsact_action_id action_id) {
 	return name;
 }
 
-inline std::vector<ecsact_enum_id> get_enum_ids(ecsact_package_id package_id) {
+ECSACT_ALWAYS_INLINE std::vector<ecsact_enum_id> get_enum_ids(
+	ecsact_package_id package_id
+) {
 	std::vector<ecsact_enum_id> enum_ids;
 	enum_ids.resize(ecsact_meta_count_enums(package_id));
 	ecsact_meta_get_enum_ids(
@@ -258,7 +269,7 @@ inline std::vector<ecsact_enum_id> get_enum_ids(ecsact_package_id package_id) {
 	return enum_ids;
 }
 
-inline std::vector<ecsact_enum_id> get_enum_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_enum_id> get_enum_ids(
 	ecsact_package_id package_id,
 	int32_t           max_size
 ) {
@@ -269,7 +280,7 @@ inline std::vector<ecsact_enum_id> get_enum_ids(
 	return enum_ids;
 }
 
-inline std::string enum_name(ecsact_enum_id enum_id) {
+ECSACT_ALWAYS_INLINE std::string enum_name(ecsact_enum_id enum_id) {
 	auto name = ecsact_meta_enum_name(enum_id);
 	if(name == nullptr) {
 		return {};
@@ -277,7 +288,7 @@ inline std::string enum_name(ecsact_enum_id enum_id) {
 	return name;
 }
 
-inline std::vector<ecsact_enum_value_id> get_enum_value_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_enum_value_id> get_enum_value_ids(
 	ecsact_enum_id enum_id,
 	int32_t        max_size
 ) {
@@ -293,7 +304,7 @@ inline std::vector<ecsact_enum_value_id> get_enum_value_ids(
 	return enum_value_ids;
 }
 
-inline std::vector<ecsact_enum_value_id> get_enum_value_ids(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_enum_value_id> get_enum_value_ids(
 	ecsact_enum_id enum_id
 ) {
 	return get_enum_value_ids(enum_id, ecsact_meta_count_enum_values(enum_id));
@@ -305,7 +316,9 @@ struct enum_value {
 	std::int32_t         value;
 };
 
-inline std::vector<enum_value> get_enum_values(ecsact_enum_id enum_id) {
+ECSACT_ALWAYS_INLINE std::vector<enum_value> get_enum_values(
+	ecsact_enum_id enum_id
+) {
 	std::vector<enum_value> enum_values;
 	auto                    size = ecsact_meta_count_enum_values(enum_id);
 	enum_values.reserve(size);
@@ -322,7 +335,7 @@ inline std::vector<enum_value> get_enum_values(ecsact_enum_id enum_id) {
 }
 
 template<typename DeclarationID>
-inline std::string decl_full_name(DeclarationID id) {
+ECSACT_ALWAYS_INLINE std::string decl_full_name(DeclarationID id) {
 	auto decl_id = ecsact_id_cast<ecsact_decl_id>(id);
 	auto full_name = ecsact_meta_decl_full_name(decl_id);
 	if(full_name == nullptr) {
@@ -332,7 +345,9 @@ inline std::string decl_full_name(DeclarationID id) {
 }
 
 template<typename SystemLikeID>
-inline std::vector<ecsact_system_id> get_child_system_ids(SystemLikeID id) {
+ECSACT_ALWAYS_INLINE std::vector<ecsact_system_id> get_child_system_ids(
+	SystemLikeID id
+) {
 	auto system_like_id = ecsact_id_cast<ecsact_system_like_id>(id);
 	std::vector<ecsact_system_id> child_system_ids;
 	child_system_ids.resize(ecsact_meta_count_child_systems(system_like_id));
@@ -345,7 +360,7 @@ inline std::vector<ecsact_system_id> get_child_system_ids(SystemLikeID id) {
 	return child_system_ids;
 }
 
-inline std::optional<ecsact_system_like_id> get_parent_system_id(
+ECSACT_ALWAYS_INLINE std::optional<ecsact_system_like_id> get_parent_system_id(
 	ecsact_system_id child_system_id
 ) {
 	auto parent_sys_id = ecsact_meta_get_parent_system_id(child_system_id);
@@ -355,7 +370,7 @@ inline std::optional<ecsact_system_like_id> get_parent_system_id(
 	return parent_sys_id;
 }
 
-inline std::vector<ecsact_system_like_id> get_top_level_systems(
+ECSACT_ALWAYS_INLINE std::vector<ecsact_system_like_id> get_top_level_systems(
 	ecsact_package_id package_id
 ) {
 	std::vector<ecsact_system_like_id> top_sys_like_ids;
@@ -369,7 +384,8 @@ inline std::vector<ecsact_system_like_id> get_top_level_systems(
 	return top_sys_like_ids;
 }
 
-inline auto get_all_system_like_ids(ecsact_package_id package_id) {
+ECSACT_ALWAYS_INLINE auto get_all_system_like_ids(ecsact_package_id package_id
+) {
 	std::vector<ecsact_system_like_id> result;
 	auto                               sys_ids = get_system_ids(package_id);
 	auto                               act_ids = get_action_ids(package_id);
@@ -390,7 +406,7 @@ inline auto get_all_system_like_ids(ecsact_package_id package_id) {
 }
 
 template<typename SystemLikeID>
-inline auto system_capabilities(SystemLikeID id) {
+ECSACT_ALWAYS_INLINE auto system_capabilities(SystemLikeID id) {
 	using result_t =
 		std::unordered_map<ecsact_component_like_id, ecsact_system_capability>;
 
@@ -420,7 +436,7 @@ inline auto system_capabilities(SystemLikeID id) {
 }
 
 template<typename SystemLikeID>
-inline auto get_system_generates_ids(SystemLikeID id) {
+ECSACT_ALWAYS_INLINE auto get_system_generates_ids(SystemLikeID id) {
 	auto sys_like_id = ecsact_id_cast<ecsact_system_like_id>(id);
 	std::vector<ecsact_system_generates_id> result;
 	result.resize(ecsact_meta_count_system_generates_ids(sys_like_id));
@@ -434,7 +450,7 @@ inline auto get_system_generates_ids(SystemLikeID id) {
 }
 
 template<typename SystemLikeID>
-inline auto get_system_generates_components(
+ECSACT_ALWAYS_INLINE auto get_system_generates_components(
 	SystemLikeID               id,
 	ecsact_system_generates_id generates_id
 ) {
@@ -469,7 +485,7 @@ inline auto get_system_generates_components(
 }
 
 template<typename SystemLikeID, typename ComponentLikeID>
-inline auto system_association_fields(
+ECSACT_ALWAYS_INLINE auto system_association_fields(
 	SystemLikeID    system_id,
 	ComponentLikeID component_id
 ) {
@@ -493,7 +509,7 @@ inline auto system_association_fields(
 }
 
 template<typename SystemLikeID, typename ComponentLikeID>
-inline auto system_association_capabilities(
+ECSACT_ALWAYS_INLINE auto system_association_capabilities(
 	SystemLikeID    system_id,
 	ComponentLikeID component_id,
 	ecsact_field_id field_id
@@ -576,7 +592,7 @@ auto system_notify_settings( //
 	return result;
 }
 
-inline auto main_package() -> std::optional<ecsact_package_id> {
+ECSACT_ALWAYS_INLINE auto main_package() -> std::optional<ecsact_package_id> {
 	auto main_pkg_id = ecsact_meta_main_package();
 	if(main_pkg_id == static_cast<ecsact_package_id>(-1)) {
 		return std::nullopt;

--- a/ecsact/runtime/serialize.hh
+++ b/ecsact/runtime/serialize.hh
@@ -16,6 +16,8 @@ namespace ecsact {
  * @returns serialized action or component bytes
  */
 template<typename T>
+	requires(!std::is_same_v<std::remove_cvref_t<T>, ecsact_component> &&
+					 !std::is_same_v<std::remove_cvref_t<T>, ecsact_action>)
 ECSACT_ALWAYS_INLINE auto serialize( //
 	const T& component_or_action
 ) -> std::vector<std::byte> {
@@ -55,69 +57,18 @@ ECSACT_ALWAYS_INLINE auto serialize( //
  * fn are passed in to work around various linking configurations.
  * @returns serialized action bytes
  */
-ECSACT_ALWAYS_INLINE auto serialize(
-	const ecsact_component&                   component,
-	decltype(ecsact_serialize_component_size) size_fn,
-	decltype(ecsact_serialize_component)      serialize_fn
+ECSACT_ALWAYS_INLINE auto serialize( //
+	const ecsact_component& component
 ) -> std::vector<std::byte> {
 	std::vector<std::byte> out_component;
-	out_component.resize(size_fn(component.component_id));
+	out_component.resize(ecsact_serialize_component_size(component.component_id));
 
-	serialize_fn(
+	ecsact_serialize_component(
 		component.component_id,
 		component.component_data,
 		reinterpret_cast<uint8_t*>(out_component.data())
 	);
 	return out_component;
-}
-
-/**
- * Serializes an ecsact_component when the type is unknown.
- * @returns serialized action bytes
- */
-ECSACT_ALWAYS_INLINE auto serialize( //
-	const ecsact_component& component
-) -> std::vector<std::byte> {
-	return serialize(
-		component,
-		ecsact_serialize_component_size,
-		ecsact_serialize_component
-	);
-}
-
-/**
- * Serializes an ecsact_action when the type is unknown. Size and serialize
- * fn are passed in to work around various linking configurations.
- * @returns serialized component bytes
- */
-ECSACT_ALWAYS_INLINE auto serialize(
-	const ecsact_action&                   action,
-	decltype(ecsact_serialize_action_size) size_fn,
-	decltype(ecsact_serialize_action)      serialize_fn
-) -> std::vector<std::byte> {
-	std::vector<std::byte> out_action;
-	out_action.resize(size_fn(action.action_id));
-
-	serialize_fn(
-		action.action_id,
-		action.action_data,
-		reinterpret_cast<uint8_t*>(out_action.data())
-	);
-	return out_action;
-}
-
-/**
- * Serializes an ecsact_action when the type is unknown.
- * @returns serialized component bytes
- */
-ECSACT_ALWAYS_INLINE auto serialize( //
-	const ecsact_action& action
-) -> std::vector<std::byte> {
-	return serialize(
-		action,
-		ecsact_serialize_action_size,
-		ecsact_serialize_action
-	);
 }
 
 /**
@@ -198,14 +149,13 @@ ECSACT_ALWAYS_INLINE auto deserialize(
  * @returns an ecsact_action
  */
 ECSACT_ALWAYS_INLINE auto deserialize(
-	const ecsact_action_id&             id,
-	std::vector<std::byte>&             serialized_action,
-	decltype(ecsact_deserialize_action) deserialize_fn
+	const ecsact_action_id& id,
+	std::vector<std::byte>& serialized_action
 ) -> std::vector<std::byte> {
 	std::vector<std::byte> action_data;
 	action_data.resize(serialized_action.size());
 
-	deserialize_fn(
+	ecsact_deserialize_action(
 		id,
 		reinterpret_cast<uint8_t*>(serialized_action.data()),
 		action_data.data()
@@ -218,42 +168,18 @@ ECSACT_ALWAYS_INLINE auto deserialize(
  * @returns an ecsact_action
  */
 ECSACT_ALWAYS_INLINE auto deserialize(
-	const ecsact_action_id& id,
-	std::vector<std::byte>& serialized_action
-) -> std::vector<std::byte> {
-	return deserialize(id, serialized_action, &ecsact_deserialize_action);
-}
-
-/**
- * Deserializes an ecsact_component when the type is unknown.
- * @returns an ecsact_action
- */
-ECSACT_ALWAYS_INLINE auto deserialize(
-	const ecsact_component_id&             id,
-	std::vector<std::byte>&                serialized_component,
-	decltype(ecsact_deserialize_component) deserialize_fn
+	const ecsact_component_id& id,
+	std::vector<std::byte>&    serialized_component
 ) -> std::vector<std::byte> {
 	std::vector<std::byte> component_data;
 	component_data.resize(serialized_component.size());
 
-	deserialize_fn(
+	ecsact_deserialize_component(
 		id,
 		reinterpret_cast<uint8_t*>(serialized_component.data()),
 		component_data.data()
 	);
 	return component_data;
-}
-
-/**
- * Deserializes an ecsact_component when the type is unknown. The deserialize
- * function is passed in to work around various linker configurations.
- * @returns an ecsact_component_id
- */
-ECSACT_ALWAYS_INLINE auto deserialize(
-	const ecsact_component_id& id,
-	std::vector<std::byte>&    serialized_component
-) -> std::vector<std::byte> {
-	return deserialize(id, serialized_component, ecsact_deserialize_component);
 }
 
 } // namespace ecsact

--- a/ecsact/runtime/serialize.hh
+++ b/ecsact/runtime/serialize.hh
@@ -4,6 +4,7 @@
 #include <span>
 #include <vector>
 #include <type_traits>
+#include "ecsact/runtime/common.h"
 #include "ecsact/runtime/serialize.h"
 #include "ecsact/runtime/core.h"
 
@@ -15,7 +16,9 @@ namespace ecsact {
  * @returns serialized action or component bytes
  */
 template<typename T>
-std::vector<std::byte> serialize(const T& component_or_action) {
+ECSACT_ALWAYS_INLINE auto serialize( //
+	const T& component_or_action
+) -> std::vector<std::byte> {
 	constexpr bool is_action =
 		std::is_same_v<std::remove_cvref_t<decltype(T::id)>, ecsact_action_id>;
 	constexpr bool is_component =
@@ -52,11 +55,11 @@ std::vector<std::byte> serialize(const T& component_or_action) {
  * fn are passed in to work around various linking configurations.
  * @returns serialized action bytes
  */
-inline std::vector<std::byte> serialize(
+ECSACT_ALWAYS_INLINE auto serialize(
 	const ecsact_component&                   component,
 	decltype(ecsact_serialize_component_size) size_fn,
 	decltype(ecsact_serialize_component)      serialize_fn
-) {
+) -> std::vector<std::byte> {
 	std::vector<std::byte> out_component;
 	out_component.resize(size_fn(component.component_id));
 
@@ -72,7 +75,9 @@ inline std::vector<std::byte> serialize(
  * Serializes an ecsact_component when the type is unknown.
  * @returns serialized action bytes
  */
-inline std::vector<std::byte> serialize(const ecsact_component& component) {
+ECSACT_ALWAYS_INLINE auto serialize( //
+	const ecsact_component& component
+) -> std::vector<std::byte> {
 	return serialize(
 		component,
 		ecsact_serialize_component_size,
@@ -85,11 +90,11 @@ inline std::vector<std::byte> serialize(const ecsact_component& component) {
  * fn are passed in to work around various linking configurations.
  * @returns serialized component bytes
  */
-inline std::vector<std::byte> serialize(
+ECSACT_ALWAYS_INLINE auto serialize(
 	const ecsact_action&                   action,
 	decltype(ecsact_serialize_action_size) size_fn,
 	decltype(ecsact_serialize_action)      serialize_fn
-) {
+) -> std::vector<std::byte> {
 	std::vector<std::byte> out_action;
 	out_action.resize(size_fn(action.action_id));
 
@@ -105,7 +110,9 @@ inline std::vector<std::byte> serialize(
  * Serializes an ecsact_action when the type is unknown.
  * @returns serialized component bytes
  */
-inline std::vector<std::byte> serialize(const ecsact_action& action) {
+ECSACT_ALWAYS_INLINE auto serialize( //
+	const ecsact_action& action
+) -> std::vector<std::byte> {
 	return serialize(
 		action,
 		ecsact_serialize_action_size,
@@ -119,10 +126,10 @@ inline std::vector<std::byte> serialize(const ecsact_action& action) {
  * @returns the deserialized action or component
  */
 template<typename T>
-T deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	std::span<std::byte> serialized_component_or_action,
 	int&                 out_read_amount
-) {
+) -> T {
 	constexpr bool is_action =
 		std::is_same_v<std::remove_cvref_t<decltype(T::id)>, ecsact_action_id>;
 	constexpr bool is_component =
@@ -159,7 +166,9 @@ T deserialize(
  * @returns the deserialized action or component
  */
 template<typename T>
-T deserialize(std::span<std::byte> serialized_component_or_action) {
+ECSACT_ALWAYS_INLINE auto deserialize(
+	std::span<std::byte> serialized_component_or_action
+) -> T {
 	[[maybe_unused]] int discarded_read_amount;
 	return ::ecsact::deserialize<T>(
 		serialized_component_or_action,
@@ -173,10 +182,10 @@ T deserialize(std::span<std::byte> serialized_component_or_action) {
  * @returns number of bytes read from the @p serialized_component_or_action
  */
 template<typename T>
-int deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	std::span<std::byte> serialized_component_or_action,
 	T&                   out_component
-) {
+) -> int {
 	int read_amount;
 	out_component =
 		::ecsact::deserialize<T>(serialized_component_or_action, read_amount);
@@ -188,11 +197,11 @@ int deserialize(
  * function is passed in to work around various linker configurations.
  * @returns an ecsact_action
  */
-inline std::vector<std::byte> deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	const ecsact_action_id&             id,
 	std::vector<std::byte>&             serialized_action,
 	decltype(ecsact_deserialize_action) deserialize_fn
-) {
+) -> std::vector<std::byte> {
 	std::vector<std::byte> action_data;
 	action_data.resize(serialized_action.size());
 
@@ -208,10 +217,10 @@ inline std::vector<std::byte> deserialize(
  * Deserializes an ecsact_component when the type is unknown.
  * @returns an ecsact_action
  */
-inline std::vector<std::byte> deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	const ecsact_action_id& id,
 	std::vector<std::byte>& serialized_action
-) {
+) -> std::vector<std::byte> {
 	return deserialize(id, serialized_action, &ecsact_deserialize_action);
 }
 
@@ -219,11 +228,11 @@ inline std::vector<std::byte> deserialize(
  * Deserializes an ecsact_component when the type is unknown.
  * @returns an ecsact_action
  */
-inline std::vector<std::byte> deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	const ecsact_component_id&             id,
 	std::vector<std::byte>&                serialized_component,
 	decltype(ecsact_deserialize_component) deserialize_fn
-) {
+) -> std::vector<std::byte> {
 	std::vector<std::byte> component_data;
 	component_data.resize(serialized_component.size());
 
@@ -240,10 +249,10 @@ inline std::vector<std::byte> deserialize(
  * function is passed in to work around various linker configurations.
  * @returns an ecsact_component_id
  */
-inline std::vector<std::byte> deserialize(
+ECSACT_ALWAYS_INLINE auto deserialize(
 	const ecsact_component_id& id,
 	std::vector<std::byte>&    serialized_component
-) {
+) -> std::vector<std::byte> {
 	return deserialize(id, serialized_component, ecsact_deserialize_component);
 }
 

--- a/ecsact/runtime/serialize.hh
+++ b/ecsact/runtime/serialize.hh
@@ -53,8 +53,7 @@ ECSACT_ALWAYS_INLINE auto serialize( //
 }
 
 /**
- * Serializes an ecsact_component when the type is unknown. Size and serialize
- * fn are passed in to work around various linking configurations.
+ * Serializes an ecsact_component when the type is unknown.
  * @returns serialized action bytes
  */
 ECSACT_ALWAYS_INLINE auto serialize( //
@@ -62,13 +61,29 @@ ECSACT_ALWAYS_INLINE auto serialize( //
 ) -> std::vector<std::byte> {
 	std::vector<std::byte> out_component;
 	out_component.resize(ecsact_serialize_component_size(component.component_id));
-
 	ecsact_serialize_component(
 		component.component_id,
 		component.component_data,
 		reinterpret_cast<uint8_t*>(out_component.data())
 	);
 	return out_component;
+}
+
+/**
+ * Serializes an ecsact_action when the type is unknown.
+ * @returns serialized action bytes
+ */
+ECSACT_ALWAYS_INLINE auto serialize( //
+	const ecsact_action& action
+) -> std::vector<std::byte> {
+	std::vector<std::byte> out_action;
+	out_action.resize(ecsact_serialize_action_size(action.action_id));
+	ecsact_serialize_action(
+		action.action_id,
+		action.action_data,
+		reinterpret_cast<uint8_t*>(out_action.data())
+	);
+	return out_action;
 }
 
 /**


### PR DESCRIPTION
* this should help with some linking errors where the wrong ecsact function would be used
