### PR TITLE
feat: indexed fields multi-add api

### DIFF
--- a/ecsact/runtime/common.h
+++ b/ecsact/runtime/common.h
@@ -533,6 +533,13 @@ typedef struct ecsact_execution_options {
 	ecsact_component* update_components;
 
 	/**
+	 * Sequential list of indexed field values for the given `update_components`.
+	 * Length is determined by `update_components_length *
+	 * update-components-total-indexed-fields-count`.
+	 */
+	const void** update_components_indexed_fields;
+
+	/**
 	 * Length of `remove_components_entities` and `remove_components` sequential
 	 * lists.
 	 */
@@ -551,6 +558,13 @@ typedef struct ecsact_execution_options {
 	 * `remove_components_length`.
 	 */
 	ecsact_component_id* remove_components;
+
+	/**
+	 * Sequential list of indexed field values for the given `remove_components`.
+	 * Length is determined by `remove_components_length *
+	 * remove-components-total-indexed-fields-count`.
+	 */
+	const void** remove_components_indexed_fields;
 
 	/**
 	 * Length of `actions` sequential list.

--- a/ecsact/runtime/core.h
+++ b/ecsact/runtime/core.h
@@ -115,7 +115,7 @@ ECSACT_CORE_API_FN(void, ecsact_get_entities)
 /**
  * Adds a component to the specified entity.
  *
- * @note This method should be avoided if possible. Adding a component in a
+ * NOTE: This method should be avoided if possible. Adding a component in a
  *       system or system execution options is preferred.
  *       SEE: `ecsact_execute_systems`
  */
@@ -127,22 +127,32 @@ ECSACT_CORE_API_FN(ecsact_add_error, ecsact_add_component)
 	const void*         component_data
 );
 
+/**
+ * Checks if a given entity has component with id @p component_id
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
+ */
 ECSACT_CORE_API_FN(bool, ecsact_has_component)
 ( //
 	ecsact_registry_id  registry_id,
 	ecsact_entity_id    entity_id,
-	ecsact_component_id component_id
+	ecsact_component_id component_id,
+	...
 );
 
 /**
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
+ *
  * @returns non-owning pointer of the component data
- * @note This method should be avoided if possible.
+ * NOTE: This method should be avoided if possible.
  */
 ECSACT_CORE_API_FN(const void*, ecsact_get_component)
 ( //
 	ecsact_registry_id  registry_id,
 	ecsact_entity_id    entity_id,
-	ecsact_component_id component_id
+	ecsact_component_id component_id,
+	...
 );
 
 /**

--- a/ecsact/runtime/core.h
+++ b/ecsact/runtime/core.h
@@ -143,7 +143,6 @@ ECSACT_CORE_API_FN(bool, ecsact_has_component)
 /**
  * @param ... if the component has indexed fields then those fields must be
  *        supplied to the variadic arguments in declaration order.
- *
  * @returns non-owning pointer of the component data
  * NOTE: This method should be avoided if possible.
  */
@@ -194,7 +193,10 @@ ECSACT_CORE_API_FN(void, ecsact_each_component)
 /**
  * Update a component for the specified entity.
  *
- * @note This method should be avoided if possible. Updating a component in a
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
+ *
+ * NOTE: This method should be avoided if possible. Updating a component in a
  *       system or system execution options is preferred.
  *       SEE: `ecsact_execute_systems`
  */
@@ -203,13 +205,17 @@ ECSACT_CORE_API_FN(ecsact_update_error, ecsact_update_component)
 	ecsact_registry_id  registry_id,
 	ecsact_entity_id    entity_id,
 	ecsact_component_id component_id,
-	const void*         component_data
+	const void*         component_data,
+	...
 );
 
 /**
  * Removes a component from the specified entity.
  *
- * @note This method should be avoided if possible. Removing a component in a
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
+ *
+ * NOTE: This method should be avoided if possible. Removing a component in a
  *       system or system execution options is preferred.
  *       SEE: `ecsact_execute_systems`
  */
@@ -217,7 +223,8 @@ ECSACT_CORE_API_FN(void, ecsact_remove_component)
 ( //
 	ecsact_registry_id  registry_id,
 	ecsact_entity_id    entity_id,
-	ecsact_component_id component_id
+	ecsact_component_id component_id,
+	...
 );
 
 /**

--- a/ecsact/runtime/core.hh
+++ b/ecsact/runtime/core.hh
@@ -635,19 +635,42 @@ public:
 		return ecsact_create_entity(_id);
 	}
 
-	template<typename Component>
+	template<typename Component, typename... AssocFields>
 		requires(!std::is_empty_v<Component>)
 	ECSACT_ALWAYS_INLINE auto get_component( //
-		ecsact_entity_id entity_id
+		ecsact_entity_id entity_id,
+		AssocFields&&... assoc_fields
 	) -> const Component& {
+		if constexpr(Component::has_assoc_fields) {
+			static_assert(
+				sizeof...(AssocFields) > 0,
+				"must be called with assoc fields"
+			);
+		}
+
 		return *reinterpret_cast<const Component*>(
-			ecsact_get_component(_id, entity_id, Component::id)
+			ecsact_get_component(_id, entity_id, Component::id, std::forward<AssocFields>(assoc_fields)...)
 		);
 	}
 
-	template<typename Component>
-	ECSACT_ALWAYS_INLINE bool has_component(ecsact_entity_id entity_id) {
-		return ecsact_has_component(_id, entity_id, Component::id);
+	template<typename Component, typename... AssocFields>
+	ECSACT_ALWAYS_INLINE bool has_component(
+		ecsact_entity_id entity_id,
+		AssocFields&&... assoc_fields
+	) {
+		if constexpr(Component::has_assoc_fields) {
+			static_assert(
+				sizeof...(AssocFields) > 0,
+				"must be called with assoc fields"
+			);
+		}
+
+		return ecsact_has_component(
+			_id,
+			entity_id,
+			Component::id,
+			std::forward<AssocFields>(assoc_fields)...
+		);
 	}
 
 	template<typename Component>
@@ -668,12 +691,46 @@ public:
 		}
 	}
 
-	template<typename Component>
+	template<typename Component, typename... AssocFields>
 	ECSACT_ALWAYS_INLINE auto update_component(
 		ecsact_entity_id entity_id,
-		const Component& component
+		const Component& component,
+		AssocFields&&... assoc_fields
 	) {
-		return ecsact_update_component(_id, entity_id, Component::id, &component);
+		if constexpr(Component::has_assoc_fields) {
+			static_assert(
+				sizeof...(AssocFields) > 0,
+				"must be called with assoc fields"
+			);
+		}
+
+		return ecsact_update_component(
+			_id,
+			entity_id,
+			Component::id,
+			&component,
+			std::forward<AssocFields>(assoc_fields)...
+		);
+	}
+
+	template<typename Component, typename... AssocFields>
+	ECSACT_ALWAYS_INLINE auto remove_component(
+		ecsact_entity_id entity_id,
+		AssocFields&&... assoc_fields
+	) -> void {
+		if constexpr(Component::has_assoc_fields) {
+			static_assert(
+				sizeof...(AssocFields) > 0,
+				"must be called with assoc fields"
+			);
+		}
+
+		return ecsact_remove_component(
+			_id,
+			entity_id,
+			Component::id,
+			std::forward<AssocFields>(assoc_fields)...
+		);
 	}
 
 	ECSACT_ALWAYS_INLINE auto count_entities() const -> int32_t {

--- a/ecsact/runtime/core.hh
+++ b/ecsact/runtime/core.hh
@@ -648,9 +648,12 @@ public:
 			);
 		}
 
-		return *reinterpret_cast<const Component*>(
-			ecsact_get_component(_id, entity_id, Component::id, std::forward<AssocFields>(assoc_fields)...)
-		);
+		return *reinterpret_cast<const Component*>(ecsact_get_component(
+			_id,
+			entity_id,
+			Component::id,
+			std::forward<AssocFields>(assoc_fields)...
+		));
 	}
 
 	template<typename Component, typename... AssocFields>

--- a/ecsact/runtime/dynamic.h
+++ b/ecsact/runtime/dynamic.h
@@ -57,11 +57,15 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_add)
  *
  * Only available if has one of these capabilities:
  *  - `ECSACT_SYS_CAP_REMOVES`
+ *
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
  */
 ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_remove)
 ( //
 	struct ecsact_system_execution_context* context,
-	ecsact_component_like_id                component_id
+	ecsact_component_like_id                component_id,
+	...
 );
 
 /**
@@ -76,12 +80,16 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_remove)
  *  - `ECSACT_SYS_CAP_READWRITE`
  *  - `ECSACT_SYS_CAP_OPTIONAL_READONLY`
  *  - `ECSACT_SYS_CAP_OPTIONAL_READWRITE`
+ *
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
  */
 ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_get)
 ( //
 	struct ecsact_system_execution_context* context,
 	ecsact_component_like_id                component_id,
-	void*                                   out_component_data
+	void*                                   out_component_data,
+	...
 );
 
 /**
@@ -90,12 +98,16 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_get)
  *  - `ECSACT_SYS_CAP_READWRITE`
  *  - `ECSACT_SYS_CAP_OPTIONAL_WRITEONLY`
  *  - `ECSACT_SYS_CAP_OPTIONAL_READWRITE`
+ *
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
  */
 ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_update)
 ( //
 	struct ecsact_system_execution_context* context,
 	ecsact_component_like_id                component_id,
-	const void*                             component_data
+	const void*                             component_data,
+	...
 );
 
 /**
@@ -106,11 +118,15 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_system_execution_context_update)
  *  - `ECSACT_SYS_CAP_OPTIONAL_READONLY`
  *  - `ECSACT_SYS_CAP_OPTIONAL_WRITEONLY`
  *  - `ECSACT_SYS_CAP_OPTIONAL_READWRITE`
+ *
+ * @param ... if the component has indexed fields then those fields must be
+ *        supplied to the variadic arguments in declaration order.
  */
 ECSACT_DYNAMIC_API_FN(bool, ecsact_system_execution_context_has)
 ( //
 	struct ecsact_system_execution_context* context,
-	ecsact_component_like_id                component_id
+	ecsact_component_like_id                component_id,
+	...
 );
 
 /**


### PR DESCRIPTION
Indexed fields introduces "association by value" which means that when you add a component to an entity it no longer is associated by its type alone. Instead components are now associated by their indexed field values.

```ecsact
component A { i32 num; }
component AssociatedWithA { A.num hello; }
```

Give the above example we have a component called `AssociatedWithA` that has an indexed field called `hello`. An entity may add `AssociatedWithA` like normal, however, if the value of `hello` is different then the component is effectively a different component.

```cpp
// Adding `AssociatedWithA` multiple times to the same entity is allowed with indexed fields
reg.add_component(entity, AssociatedWithA{.hello = 10});
reg.add_component(entity, AssociatedWithA{.hello = 42});

reg.add_component(entity, AssociatedWithA{.hello = 10}); // error, not allowed. already component with hello=10
```

This adds a wrinkle with `remove_component`, `update_component`, and `has_component`. We no longer have the ability to specify _which_ `AssociatedWithA` component to update or remove. This PR introduces slight tweaks to our `remove_component` and `update_component` methods requiring you to pass in the indexed fields values.

```cpp
reg.has_component<AssociatedWithA>(entity, 42); // returns true
reg.has_component<AssociatedWithA>(entity, 10); // returns true

// Remove the component with hello=10
reg.remove_component<AssociatedWithA>(entity, 10);

reg.has_component<AssociatedWithA>(entity, 42); // returns true
reg.has_component<AssociatedWithA>(entity, 10); // returns false
```

These of course translate to the `context` methods as well.

```cpp
context.remove<AssociatedWithA>(10);
// etc.
```

You can also update an indexed field as well. Very similar to the remove example above.

```cpp
reg.has_component<AssociatedWithA>(entity, 42); // returns true

reg.update_component(entity, AssociatedWithA{.hello = 55}, 42);

reg.has_component<AssociatedWithA>(entity, 42); // returns false
reg.has_component<AssociatedWithA>(entity, 55); // returns true
```

It's worth noting that you cannot call `has`, `get`, `update`, or `remove` without also giving the indexed fields. Doing so is considered user error, but our C++ (and other language) wrappers are designed to prevent these mistakes from happening.


